### PR TITLE
Reports API: "Undeclared name: admin" - Adding needed import

### DIFF
--- a/admin_sdk/reports/quickstart.go
+++ b/admin_sdk/reports/quickstart.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"time"
 
+	admin "google.golang.org/api/admin/reports/v1"
+	
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"

--- a/admin_sdk/reports/quickstart.go
+++ b/admin_sdk/reports/quickstart.go
@@ -25,13 +25,11 @@ import (
 	"net/http"
 	"os"
 	"time"
-
-	admin "google.golang.org/api/admin/reports/v1"
 	
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/admin/reports/v1"
+	admin "google.golang.org/api/admin/reports/v1"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.


### PR DESCRIPTION
Adding import statement `admin "google.golang.org/api/admin/reports/v1"`, which is referred but not included.

Adding this statement will allow execution.