### PR TITLE
Fixed missing import references

### DIFF
--- a/admin_sdk/directory/quickstart.go
+++ b/admin_sdk/directory/quickstart.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/admin/directory/v1"
+	directory "google.golang.org/api/admin/directory/v1"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/admin_sdk/reports/quickstart.go
+++ b/admin_sdk/reports/quickstart.go
@@ -25,11 +25,11 @@ import (
 	"net/http"
 	"os"
 	"time"
-
+	
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/admin/reports/v1"
+	admin "google.golang.org/api/admin/reports/v1"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/admin_sdk/reseller/quickstart.go
+++ b/admin_sdk/reseller/quickstart.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/reseller/v1"
+	reseller "google.golang.org/api/reseller/v1"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/apps_script/execute/execute.go
+++ b/apps_script/execute/execute.go
@@ -19,14 +19,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"golang.org/x/oauth2/google"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
-	"google.golang.org/api/script/v1"
+	"golang.org/x/oauth2/google"
+	script "google.golang.org/api/script/v1"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.
@@ -84,7 +85,6 @@ func saveToken(path string, token *oauth2.Token) {
 	json.NewEncoder(f).Encode(token)
 }
 
-
 func main() {
 	// [START apps_script_api_execute]
 
@@ -126,7 +126,7 @@ func main() {
 		// The values of this map are the script's 'errorMessage' and
 		// 'errorType', and an array of stack trace elements (which also need to
 		// be cast as maps).
-		var details map[string]interface{};
+		var details map[string]interface{}
 		json.Unmarshal(resp.Error.Details[0], &details)
 		fmt.Printf("Script details message: %s\n", details["errorMessage"])
 
@@ -143,7 +143,7 @@ func main() {
 		// based upon what types the Apps Script function returns. Here, the
 		// function returns an Apps Script Object with String keys and values, so
 		// must be cast into a map (folderSet).
-		var r map[string]interface{};
+		var r map[string]interface{}
 		json.Unmarshal(resp.Response, &r)
 		folderSet := r["result"].(map[string]interface{})
 		if len(folderSet) == 0 {

--- a/apps_script/quickstart/quickstart.go
+++ b/apps_script/quickstart/quickstart.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/script/v1"
+	script "google.golang.org/api/script/v1"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/calendar/quickstart/quickstart.go
+++ b/calendar/quickstart/quickstart.go
@@ -29,7 +29,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/calendar/v3"
+	calendar "google.golang.org/api/calendar/v3"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/classroom/quickstart/quickstart.go
+++ b/classroom/quickstart/quickstart.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/classroom/v1"
+	classroom "google.golang.org/api/classroom/v1"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/classroom/snippets/createCourse.go
+++ b/classroom/snippets/createCourse.go
@@ -17,31 +17,32 @@
 package main
 
 import (
-        "fmt"
-        "google.golang.org/api/classroom/v1"
-        "log"
-        "net/http"
+	"fmt"
+	"log"
+	"net/http"
+
+	classroom "google.golang.org/api/classroom/v1"
 )
 
 func createCourse(client *http.Client) {
-        srv, err := classroom.New(client)
-        if err != nil {
-                log.Fatalf("Unable to create classroom Client %v", err)
-        }
-        // [START classroom_create_course]
-        c := &classroom.Course{
-                Name: "10th Grade Biology",
-                Section: "Period 2",
-                DescriptionHeading: "Welcome to 10th Grade Biology",
-                Description: "We'll be learning about about the structure of living creatures from a combination of textbooks, guest lectures, and lab work. Expect to be excited!",
-                Room: "301",
-                OwnerId: "me",
-                CourseState: "PROVISIONED",
-        }
-        course, err := srv.Courses.Create(c).Do()
-        if err != nil {
-                log.Fatalf("Course unable to be created %v", err)
-        }
-        // [END classroom_create_course]
-        fmt.Printf("Created course: %v", course.Id)
+	srv, err := classroom.New(client)
+	if err != nil {
+		log.Fatalf("Unable to create classroom Client %v", err)
+	}
+	// [START classroom_create_course]
+	c := &classroom.Course{
+		Name:               "10th Grade Biology",
+		Section:            "Period 2",
+		DescriptionHeading: "Welcome to 10th Grade Biology",
+		Description:        "We'll be learning about about the structure of living creatures from a combination of textbooks, guest lectures, and lab work. Expect to be excited!",
+		Room:               "301",
+		OwnerId:            "me",
+		CourseState:        "PROVISIONED",
+	}
+	course, err := srv.Courses.Create(c).Do()
+	if err != nil {
+		log.Fatalf("Course unable to be created %v", err)
+	}
+	// [END classroom_create_course]
+	fmt.Printf("Created course: %v", course.Id)
 }

--- a/classroom/snippets/getCourse.go
+++ b/classroom/snippets/getCourse.go
@@ -17,40 +17,41 @@
 package main
 
 import (
-        "fmt"
-        "golang.org/x/oauth2/google"
-        "google.golang.org/api/classroom/v1"
-        "io/ioutil"
-        "log"
-        "net/http"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"golang.org/x/oauth2/google"
+	classroom "google.golang.org/api/classroom/v1"
 )
 
 func getCourse(client *http.Client) {
-        // [START classroom_get_course]
-        srv, err := classroom.New(client)
-        if err != nil {
-                log.Fatalf("Unable to create classroom Client %v", err)
-        }
-        id := "123456"
-        course, err := srv.Courses.Get(id).Do()
-        if err != nil {
-                log.Fatalf("Course unable to be retrieved %v", err)
-        }
-        // [END classroom_get_course]
-        fmt.Printf("Course with ID %v found.", course.Id)
+	// [START classroom_get_course]
+	srv, err := classroom.New(client)
+	if err != nil {
+		log.Fatalf("Unable to create classroom Client %v", err)
+	}
+	id := "123456"
+	course, err := srv.Courses.Get(id).Do()
+	if err != nil {
+		log.Fatalf("Course unable to be retrieved %v", err)
+	}
+	// [END classroom_get_course]
+	fmt.Printf("Course with ID %v found.", course.Id)
 }
 
 func main() {
-        b, err := ioutil.ReadFile("credentials.json")
-        if err != nil {
-                log.Fatalf("Unable to read client secret file: %v", err)
-        }
+	b, err := ioutil.ReadFile("credentials.json")
+	if err != nil {
+		log.Fatalf("Unable to read client secret file: %v", err)
+	}
 
-        // If modifying these scopes, delete your previously saved token.json.
-        config, err := google.ConfigFromJSON(b, classroom.ClassroomCoursesScope)
-        if err != nil {
-                log.Fatalf("Unable to parse client secret file to config: %v", err)
-        }
-        client := getClient(config)
-        getCourse(client)
+	// If modifying these scopes, delete your previously saved token.json.
+	config, err := google.ConfigFromJSON(b, classroom.ClassroomCoursesScope)
+	if err != nil {
+		log.Fatalf("Unable to parse client secret file to config: %v", err)
+	}
+	client := getClient(config)
+	getCourse(client)
 }

--- a/docs/quickstart/quickstart.go
+++ b/docs/quickstart/quickstart.go
@@ -29,7 +29,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/docs/v1"
+	docs "google.golang.org/api/docs/v1"
 )
 
 // Retrieves a token, saves the token, then returns the generated client.

--- a/drive/activity-v2/quickstart/quickstart.go
+++ b/drive/activity-v2/quickstart/quickstart.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/driveactivity/v2"
+	driveactivity "google.golang.org/api/driveactivity/v2"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/drive/activity/quickstart/quickstart.go
+++ b/drive/activity/quickstart/quickstart.go
@@ -29,7 +29,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/appsactivity/v1"
+	appsactivity "google.golang.org/api/appsactivity/v1"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/drive/quickstart/quickstart.go
+++ b/drive/quickstart/quickstart.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/drive/v3"
+	drive "google.golang.org/api/drive/v3"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/gmail/quickstart/quickstart.go
+++ b/gmail/quickstart/quickstart.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/gmail/v1"
+	gmail "google.golang.org/api/gmail/v1"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/people/quickstart/quickstart.go
+++ b/people/quickstart/quickstart.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/people/v1"
+	people "google.golang.org/api/people/v1"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/sheets/quickstart/quickstart.go
+++ b/sheets/quickstart/quickstart.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/sheets/v4"
+	sheets "google.golang.org/api/sheets/v4"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/slides/quickstart/quickstart.go
+++ b/slides/quickstart/quickstart.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/slides/v1"
+	slides "google.golang.org/api/slides/v1"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.

--- a/slides/snippets/oauth.go
+++ b/slides/snippets/oauth.go
@@ -2,11 +2,12 @@ package snippets
 
 import (
 	"log"
+
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/drive/v2"
-	"google.golang.org/api/sheets/v4"
-	"google.golang.org/api/slides/v1"
+	drive "google.golang.org/api/drive/v2"
+	sheets "google.golang.org/api/sheets/v4"
+	slides "google.golang.org/api/slides/v1"
 )
 
 // A group of Google services.

--- a/slides/snippets/presentations.go
+++ b/slides/snippets/presentations.go
@@ -3,8 +3,9 @@ package snippets
 import (
 	"fmt"
 	"log"
-	"google.golang.org/api/drive/v2"
-	"google.golang.org/api/slides/v1"
+
+	drive "google.golang.org/api/drive/v2"
+	slides "google.golang.org/api/slides/v1"
 )
 
 func createPresentation() string {

--- a/slides/snippets/test_utils.go
+++ b/slides/snippets/test_utils.go
@@ -1,8 +1,9 @@
 package snippets
 
 import (
-	"google.golang.org/api/slides/v1"
 	"log"
+
+	slides "google.golang.org/api/slides/v1"
 )
 
 func deleteFileOnCleanup(id string) {

--- a/tasks/quickstart/quickstart.go
+++ b/tasks/quickstart/quickstart.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/tasks/v1"
+	tasks "google.golang.org/api/tasks/v1"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.


### PR DESCRIPTION
In reference to commit [1b9ee5e](https://github.com/googleworkspace/go-samples/commit/1b9ee5eaa2b2b8d440486a7cfbff755dc9ad90a7), this PR will address all the remaining examples that are missing the import reference, and results in the compiler not finding the package in question.

This is due to the import statements referencing a version (`google.golang.org/api/tasks/v1`), and the method calls are under the package name `tasks`.