### PR TITLE
docs: refactor getTokenFromWeb for OAuth2 callback handling

### DIFF
--- a/gmail/quickstart/quickstart.go
+++ b/gmail/quickstart/quickstart.go
@@ -47,15 +47,48 @@ func getClient(config *oauth2.Config) *http.Client {
 
 // Request a token from the web, then returns the retrieved token.
 func getTokenFromWeb(config *oauth2.Config) *oauth2.Token {
-	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
-	fmt.Printf("Go to the following link in your browser then type the "+
-		"authorization code: \n%v\n", authURL)
+	// Set the redirect URL to match the local server we are about to start
+	config.RedirectURL = "http://localhost:8080"
 
-	var authCode string
-	if _, err := fmt.Scan(&authCode); err != nil {
-		log.Fatalf("Unable to read authorization code: %v", err)
+	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
+	fmt.Printf("Go to the following link in your browser: \n%v\n", authURL)
+
+	// Create a channel to wait for the authorization code
+	codeCh := make(chan string)
+
+	// Create a local HTTP multiplexer and server to listen for the OAuth2 callback
+	m := http.NewServeMux()
+	server := &http.Server{Addr: ":8080", Handler: m}
+
+	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		code := r.URL.Query().Get("code")
+		if code != "" {
+			fmt.Fprintf(w, "Authentication successful! You may close this window.")
+			codeCh <- code
+		} else {
+			fmt.Fprintf(w, "Failed to get authorization code. You may close this window.")
+			codeCh <- ""
+		}
+	})
+
+	// Start the server in a goroutine
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Unable to start local web server: %v", err)
+		}
+	}()
+
+	// Wait for the code to be extracted from the callback
+	authCode := <-codeCh
+
+	// Shutdown the server gracefully now that we have the code
+	server.Shutdown(context.Background())
+
+	if authCode == "" {
+		log.Fatalf("Authorization failed or code not returned.")
 	}
 
+	// Exchange the authorization code for an access token
 	tok, err := config.Exchange(context.TODO(), authCode)
 	if err != nil {
 		log.Fatalf("Unable to retrieve token from web: %v", err)

--- a/gmail/quickstart/quickstart.go
+++ b/gmail/quickstart/quickstart.go
@@ -19,6 +19,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"

--- a/gmail/quickstart/quickstart.go
+++ b/gmail/quickstart/quickstart.go
@@ -22,8 +22,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
+	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -45,51 +47,87 @@ func getClient(config *oauth2.Config) *http.Client {
 	return config.Client(context.Background(), tok)
 }
 
+// generateState creates a secure random string for the OAuth2 state parameter.
+func generateState() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+// Request a token from the web, then returns the retrieved token.
 // Request a token from the web, then returns the retrieved token.
 func getTokenFromWeb(config *oauth2.Config) *oauth2.Token {
-	// Set the redirect URL to match the local server we are about to start
-	config.RedirectURL = "http://localhost:8080"
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		log.Fatalf("Unable to start local listener: %v", err)
+	}
 
-	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
+	port := listener.Addr().(*net.TCPAddr).Port
+	config.RedirectURL = fmt.Sprintf("http://localhost:%d", port)
+
+	// Generate a dynamic, cryptographically secure state parameter
+	state := generateState()
+
+	authURL := config.AuthCodeURL(state, oauth2.AccessTypeOffline)
 	fmt.Printf("Go to the following link in your browser: \n%v\n", authURL)
 
-	// Create a channel to wait for the authorization code
+	// Channels to handle successful codes and errors
 	codeCh := make(chan string)
+	errCh := make(chan error)
 
-	// Create a local HTTP multiplexer and server to listen for the OAuth2 callback
 	m := http.NewServeMux()
-	server := &http.Server{Addr: ":8080", Handler: m}
+	server := &http.Server{Handler: m}
 
 	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if errStr := r.URL.Query().Get("error"); errStr != "" {
+			fmt.Fprintf(w, "Authentication error: %s. You may close this window.", errStr)
+			errCh <- errors.New(errStr)
+			return
+		}
+
+		returnedState := r.URL.Query().Get("state")
+		if returnedState != state {
+			fmt.Fprintf(w, "Security error: invalid state parameter. You may close this window.")
+			errCh <- errors.New("invalid state parameter")
+			return
+		}
+
 		code := r.URL.Query().Get("code")
 		if code != "" {
 			fmt.Fprintf(w, "Authentication successful! You may close this window.")
 			codeCh <- code
 		} else {
 			fmt.Fprintf(w, "Failed to get authorization code. You may close this window.")
-			codeCh <- ""
+			errCh <- errors.New("authorization code missing")
 		}
 	})
 
-	// Start the server in a goroutine
 	go func() {
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("Unable to start local web server: %v", err)
 		}
 	}()
 
-	// Wait for the code to be extracted from the callback
-	authCode := <-codeCh
+	var authCode string
 
-	// Shutdown the server gracefully now that we have the code
-	server.Shutdown(context.Background())
-
-	if authCode == "" {
-		log.Fatalf("Authorization failed or code not returned.")
+	// Wait for a successful code, an error, or a timeout
+	select {
+	case authCode = <-codeCh:
+		// Success case, proceed to shutdown and exchange
+	case callbackErr := <-errCh:
+		server.Shutdown(context.Background())
+		log.Fatalf("Authorization failed during callback: %v", callbackErr)
+	case <-time.After(3 * time.Minute):
+		// Timeout case: user took too long or closed the browser
+		server.Shutdown(context.Background())
+		log.Fatalf("Authorization timed out after 3 minutes. Please try again.")
 	}
 
-	// Exchange the authorization code for an access token
-	tok, err := config.Exchange(context.TODO(), authCode)
+	// Shutdown the server gracefully upon success
+	server.Shutdown(context.Background())
+
+	// Exchange the authorization code for an access token using context.Background()
+	tok, err := config.Exchange(context.Background(), authCode)
 	if err != nil {
 		log.Fatalf("Unable to retrieve token from web: %v", err)
 	}

--- a/gmail/quickstart/quickstart.go
+++ b/gmail/quickstart/quickstart.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net"


### PR DESCRIPTION
Updated the getTokenFromWeb function to set the redirect URL and handle the OAuth2 callback with a local server. Fixes issue caused by the deprecation of Google's Out-Of-Band (OOB) OAuth flow.